### PR TITLE
Default key available for DeepAI #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ pip3 install -r ./requirements.txt
 
 ### Generating text dynamically
 
-To make use of a feature that will generate the text of your tip dynamically on each submission, make a free account at [DeepAI](https://deepai.org/machine-learning-model/text-generator) and use the API key generated for you found on your profile page. Set the environment variable 'DEEP_AI_KEY' to this value by running `export DEEP_AI_KEY=your AI key goes here` (you may need to do this every time you start the program). This will make it harder to automatically filter out these tips.
+To make use of a feature that will generate the text of your tip dynamically on each submission, set the --generate option on the command line. This will make it harder to automatically filter out these tips.
+
+By default this will use a generic API key, which may be disabled if used excessively. If you'd like to use your own key, make a free account at [DeepAI](https://deepai.org/machine-learning-model/text-generator) and use the API key generated for you found on your profile page. Set the environment variable 'DEEP_AI_KEY' to this value by running `export DEEP_AI_KEY=your AI key goes here` (you may need to do this every time you start the program). 
 
 #### Running the program
 

--- a/bot/arguments.py
+++ b/bot/arguments.py
@@ -3,5 +3,6 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('-v', '--verbose', help='Increases the verbosity of the output.', action='store_true')
 parser.add_argument('-c', '--count', help='Set a maximum number of times to successfully submit to the form.', type=int, default=None)
+parser.add_argument('-g', '--generate', help='Generate GPT2 text from DeepAI API with key set by environment variable or default.', action='store_true')
 
 args = parser.parse_args()

--- a/bot/data.py
+++ b/bot/data.py
@@ -5,7 +5,11 @@ import random
 import requests
 import json
 
+from .arguments import args
+from .logger import logger
+
 TEXT_GEN_API_VAR = 'DEEP_AI_KEY'
+DEFAULT_KEY = '9d414130-ca3d-4169-ab5e-0c0c2f17b65f'
 
 words = [
   'The', 'he', 'at', 'but', 'there', 'of', 'was', 'be', 'not', 'use', 'and', 'for', 'this', 'what', 'an', 'a', 'on', 'have', 'all', 'each',
@@ -253,13 +257,20 @@ def sign_up_page():
 
 
 def get_tip_body():
+  rv = ''
   # If we have an API key for GPT2, use it
-  if TEXT_GEN_API_VAR in os.environ:
+  if args.generate:
+    key = DEFAULT_KEY
+    if TEXT_GEN_API_VAR in os.environ:
+      key = os.environ[TEXT_GEN_API_VAR]
+      logger.info('Using key from environment: ' + key)
+    else:
+      logger.info('Using default key.')
     prompt = random.choice(gpt2_prompts)
     r = requests.post(
       "https://api.deepai.org/api/text-generator", data={
         'text': prompt,
-      }, headers={'api-key': os.environ[TEXT_GEN_API_VAR]}
+      }, headers={'api-key': key}
     )
     rv = str(r.json()['output'].encode('utf-8'))
     # cut out the prompt, which comes from a limited set and can be filtered on
@@ -267,9 +278,9 @@ def get_tip_body():
     # take string up through last complete sentence since we occasionally get trailing words
     if '.' in rv:
       rv = rv[0:rv.rindex('.')] + '.'
-    return rv
   else:
     # standard tip body generation
-    return random.choice(gop_members) + ' took their mistress ' + random.choice(firstNames) + ' ' + random.choice(
+    rv = random.choice(gop_members) + ' took their mistress ' + random.choice(firstNames) + ' ' + random.choice(
       lastNames
     ) + ' to get an abortion after their affair.'
+  logger.info('Generated text:\n' + rv)


### PR DESCRIPTION
Partially address #3 by setting a default API key, accessible by the --generate command line option (off by default for now).
Also added logging which will show user what text is being sent.