### PR TITLE
Supply target's IP address // Fixing form nonce issues

### DIFF
--- a/bot/arguments.py
+++ b/bot/arguments.py
@@ -3,6 +3,22 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('-v', '--verbose', help='Increases the verbosity of the output.', action='store_true')
 parser.add_argument('-c', '--count', help='Set a maximum number of times to successfully submit to the form.', type=int, default=None)
-parser.add_argument('-g', '--generate', help='Generate GPT2 text from DeepAI API with key set by environment variable or default.', action='store_true')
+parser.add_argument(
+  '-g', '--generate', help='Generate GPT2 text from DeepAI API with key set by environment variable or default.', action='store_true'
+)
+parser.add_argument(
+  '-t',
+  '--target',
+  help='Specify the target\'s IP address. Useful if the domain is not working correctly on it\'s own.',
+  type=str,
+  default=None
+)
+parser.add_argument(
+  '-d',
+  '--domain',
+  help='Specify the target\'s fully qualified domain (FQDN). Useful if the target switches domains. Defaults to prolifewhistleblower.com',
+  type=str,
+  default='prolifewhistleblower.com'
+)
 
 args = parser.parse_args()

--- a/bot/arguments.py
+++ b/bot/arguments.py
@@ -20,5 +20,8 @@ parser.add_argument(
   type=str,
   default='prolifewhistleblower.com'
 )
+parser.add_argument(
+  '-n', '--nonce', help='Specify a nonce to use for the form submission. Skips the request for a nonce.', type=str, default=None
+)
 
 args = parser.parse_args()

--- a/bot/data.py
+++ b/bot/data.py
@@ -40,7 +40,7 @@ with open(os.path.join(os.getcwd(), "bot", "data", "firstnameBoy.json")) as fnb:
 with open(os.path.join(os.getcwd(), "bot", "data", "lastname.json")) as ln:
   lastNames = json.loads(ln.read())
   lastNames = lastNames["names"]
-  
+
 with open(os.path.join(os.getcwd(), "bot", "data", "zips.json")) as z:
   zip_codes = json.loads(z.read())
 
@@ -62,24 +62,24 @@ info_location = [
 # TX IPs gathered from here: https://www.xmyip.com/ip-addresses/united--states/texas
 ips = [
   "64.46.160.",  # Addison
-  "24.27.72.", # Allen
-  "65.65.132.", # Alpine
-  "50.175.228.", # Alvin
-  "50.175.229.", # Alvin
+  "24.27.72.",  # Allen
+  "65.65.132.",  # Alpine
+  "50.175.228.",  # Alvin
+  "50.175.229.",  # Alvin
   "50.26.131.",  # Amarillo
-  "23.117.126.", # Arlington
+  "23.117.126.",  # Arlington
   "8.34.145.",  # Austin
-  "24.153.156.", # Austin
+  "24.153.156.",  # Austin
   "24.155.228.",  # Austin
-  "66.193.112.", # Austin
-  "66.193.113.", # Austin
-  "50.94.23.", # Austin
-  "24.173.59.", # Beaumont
-  "63.174.138.", # Beaumont
-  "24.219.225.", # Benbrook
+  "66.193.112.",  # Austin
+  "66.193.113.",  # Austin
+  "50.94.23.",  # Austin
+  "24.173.59.",  # Beaumont
+  "63.174.138.",  # Beaumont
+  "24.219.225.",  # Benbrook
   "24.32.117.",  # Clarksville
-  "50.15.108.", # Conroe
-  "50.21.240.", # Conroe
+  "50.15.108.",  # Conroe
+  "50.21.240.",  # Conroe
   "66.170.212.",  # Conroe
   "67.67.45.",  # Coppell
   "12.53.23.",  # Dallas
@@ -87,67 +87,67 @@ ips = [
   "12.134.216.",  # Dallas
   "12.135.64.",  # Dallas
   "12.209.171.",  # Dallas
-  "32.144.6.", # Dallas
-  "32.144.7.", # Dallas
-  "17.253.118.", # Dallas
-  "67.216.80.", # Dallas
-  "67.216.81.", # Dallas
-  "67.216.82.", # Dallas
-  "67.216.83.", # Dallas
-  "67.216.84.", # Dallas
-  "67.216.85.", # Dallas
-  "67.216.86.", # Dallas
-  "67.216.87.", # Dallas
-  "67.216.88.", # Dallas
-  "67.216.89.", # Dallas
-  "67.216.90.", # Dallas
-  "67.216.91.", # Dallas
-  "67.216.92.", # Dallas
-  "67.216.93.", # Dallas
-  "67.216.94.", # Dallas
-  "67.216.95.", # Dallas
-  "23.119.13.", # Dallas
-  "23.119.14.", # Dallas
-  "23.119.15.", # Dallas
-  "64.197.59.", # Dallas
-  "32.153.78.", # Dallas
-  "32.153.79.", # Dallas
-  "32.153.80.", # Dallas
-  "32.153.81.", # Dallas
-  "32.153.82.", # Dallas
-  "32.153.83.", # Dallas
-  "32.153.84.", # Dallas
-  "32.153.85.", # Dallas
-  "32.153.86.", # Dallas
-  "32.153.87.", # Dallas
-  "32.153.88.", # Dallas
-  "32.153.89.", # Dallas
-  "32.153.90.", # Dallas
-  "32.153.91.", # Dallas
-  "32.153.92.", # Dallas
-  "32.153.93.", # Dallas
-  "32.153.94.", # Dallas
-  "32.153.95.", # Dallas
-  "32.153.96.", # Dallas
-  "32.153.97.", # Dallas
-  "32.153.98.", # Dallas
-  "4.68.19.", # Dallas
-  "63.133.167.", # Dallas
-  "66.155.134.", # Dallas
-  "66.155.135.", # Dallas
-  "68.109.248.", # Dallas
-  "64.56.170.", # Dallas
-  "32.149.194.", # Dallas
-  "32.149.195.", # Dallas
-  "32.149.196.", # Dallas
-  "32.149.197.", # Dallas
-  "32.168.139.", # Dallas
-  "68.90.101.", # Dallas
-  "24.242.248.", # Dallas
-  "23.33.244.", # Dallas
-  "23.33.245.", # Dallas
-  "23.33.246.", # Dallas
-  "23.33.247.", # Dallas
+  "32.144.6.",  # Dallas
+  "32.144.7.",  # Dallas
+  "17.253.118.",  # Dallas
+  "67.216.80.",  # Dallas
+  "67.216.81.",  # Dallas
+  "67.216.82.",  # Dallas
+  "67.216.83.",  # Dallas
+  "67.216.84.",  # Dallas
+  "67.216.85.",  # Dallas
+  "67.216.86.",  # Dallas
+  "67.216.87.",  # Dallas
+  "67.216.88.",  # Dallas
+  "67.216.89.",  # Dallas
+  "67.216.90.",  # Dallas
+  "67.216.91.",  # Dallas
+  "67.216.92.",  # Dallas
+  "67.216.93.",  # Dallas
+  "67.216.94.",  # Dallas
+  "67.216.95.",  # Dallas
+  "23.119.13.",  # Dallas
+  "23.119.14.",  # Dallas
+  "23.119.15.",  # Dallas
+  "64.197.59.",  # Dallas
+  "32.153.78.",  # Dallas
+  "32.153.79.",  # Dallas
+  "32.153.80.",  # Dallas
+  "32.153.81.",  # Dallas
+  "32.153.82.",  # Dallas
+  "32.153.83.",  # Dallas
+  "32.153.84.",  # Dallas
+  "32.153.85.",  # Dallas
+  "32.153.86.",  # Dallas
+  "32.153.87.",  # Dallas
+  "32.153.88.",  # Dallas
+  "32.153.89.",  # Dallas
+  "32.153.90.",  # Dallas
+  "32.153.91.",  # Dallas
+  "32.153.92.",  # Dallas
+  "32.153.93.",  # Dallas
+  "32.153.94.",  # Dallas
+  "32.153.95.",  # Dallas
+  "32.153.96.",  # Dallas
+  "32.153.97.",  # Dallas
+  "32.153.98.",  # Dallas
+  "4.68.19.",  # Dallas
+  "63.133.167.",  # Dallas
+  "66.155.134.",  # Dallas
+  "66.155.135.",  # Dallas
+  "68.109.248.",  # Dallas
+  "64.56.170.",  # Dallas
+  "32.149.194.",  # Dallas
+  "32.149.195.",  # Dallas
+  "32.149.196.",  # Dallas
+  "32.149.197.",  # Dallas
+  "32.168.139.",  # Dallas
+  "68.90.101.",  # Dallas
+  "24.242.248.",  # Dallas
+  "23.33.244.",  # Dallas
+  "23.33.245.",  # Dallas
+  "23.33.246.",  # Dallas
+  "23.33.247.",  # Dallas
   "23.95.39.",  # Dallas
   "23.216.55.",  # Dallas
   "23.218.192.",  # Dallas
@@ -159,33 +159,33 @@ ips = [
   "63.234.233.",  # Dallas
   "64.195.173.",  # Dallas
   "65.44.75.",  # Dallas
-  "66.106.98.", # Dallas
+  "66.106.98.",  # Dallas
   "67.48.192.",  # Dallas
   "68.95.146.",  # Dallas
-  "47.184.118.", # Denton
-  "47.184.119.", # Denton
-  "47.184.120.", # Denton
-  "47.184.121.", # Denton
-  "24.206.145.", # Denton
+  "47.184.118.",  # Denton
+  "47.184.119.",  # Denton
+  "47.184.120.",  # Denton
+  "47.184.121.",  # Denton
+  "24.206.145.",  # Denton
   "24.219.171.",  # Denton
   "68.116.255.",  # Denton
   "67.10.46.",  # Edinburg
   "47.185.148.",  # Flower Mound
   "12.251.72.",  # Fort Stockton
-  "12.184.253.", # Fort Worth
+  "12.184.253.",  # Fort Worth
   "12.210.27.",  # Fort Worth
-  "47.32.223.", # Fort Worth
-  "12.203.146.", # Fort Worth
-  "12.203.147.", # Fort Worth
-  "12.184.254.", # Fort Worth
-  "12.90.92.", # Fort Worth
+  "47.32.223.",  # Fort Worth
+  "12.203.146.",  # Fort Worth
+  "12.203.147.",  # Fort Worth
+  "12.184.254.",  # Fort Worth
+  "12.90.92.",  # Fort Worth
   "24.219.163.",  # Fort Worth
   "50.11.19.",  # Fort Worth
   "68.113.154.",  # Fort Worth
-  "50.207.209.", # Friendswood
-  "64.134.76.", # Grapevine
-  "66.169.188.", # Haltom City
-  "66.169.189.", # Haltom City
+  "50.207.209.",  # Friendswood
+  "64.134.76.",  # Grapevine
+  "66.169.188.",  # Haltom City
+  "66.169.189.",  # Haltom City
   "12.8.38.",  # Houston
   "12.68.245.",  # Houston
   "12.198.216.",  # Houston
@@ -200,40 +200,40 @@ ips = [
   "45.33.171.",  # Houston
   "65.124.92.",  # Houston
   "66.67.94.",  # Houston
-  "66.78.229.", # Houston
-  "66.78.230.", # Houston
-  "66.78.231.", # Houston
-  "66.161.197.", # Houston
-  "66.3.44.", # Houston
-  "66.3.45.", # Houston
-  "66.3.46.", # Houston
-  "50.162.44.", # Houston
-  "45.17.135.", # Houston
-  "68.91.35.", # Hurst
-  "50.84.165.", # Irving
+  "66.78.229.",  # Houston
+  "66.78.230.",  # Houston
+  "66.78.231.",  # Houston
+  "66.161.197.",  # Houston
+  "66.3.44.",  # Houston
+  "66.3.45.",  # Houston
+  "66.3.46.",  # Houston
+  "50.162.44.",  # Houston
+  "45.17.135.",  # Houston
+  "68.91.35.",  # Hurst
+  "50.84.165.",  # Irving
   "50.84.181.",  # Irving
-  "64.129.174.", # Irving
-  "64.195.138.", # Irving
-  "64.195.139.", # Irving
-  "64.195.140.", # Irving
-  "64.195.141.", # Irving
-  "64.195.142.", # Irving
-  "64.195.143.", # Irving
+  "64.129.174.",  # Irving
+  "64.195.138.",  # Irving
+  "64.195.139.",  # Irving
+  "64.195.140.",  # Irving
+  "64.195.141.",  # Irving
+  "64.195.142.",  # Irving
+  "64.195.143.",  # Irving
   "66.25.22.",  # Irving
   "24.32.224.",  # Kingwood
   "68.88.193.",  # Lancaster
-  "47.187.76.", # Lewisville
-  "12.38.125.", # Lubbock
+  "47.187.76.",  # Lewisville
+  "12.38.125.",  # Lubbock
   "38.114.200.",  # Lufkin
-  "24.243.98.", # McAllen
-  "67.10.39.", # McAllen
-  "24.243.150.", # McAllen
-  "24.243.151.", # McAllen
-  "24.243.152.", # McAllen
+  "24.243.98.",  # McAllen
+  "67.10.39.",  # McAllen
+  "24.243.150.",  # McAllen
+  "24.243.151.",  # McAllen
+  "24.243.152.",  # McAllen
   "24.242.89.",  # Pflugerville
   "67.10.20.",  # Pharr
   "24.173.213.",  # Plano
-  "47.185.248.", # Plano
+  "47.185.248.",  # Plano
   "50.84.81.",  # Plano
   "66.140.20."  # Plano
   "68.22.119.",  # Plano
@@ -244,60 +244,60 @@ ips = [
   "23.123.121.",  # Richardson
   "23.126.17.",  # Richardson
   "63.204.90.",  # Richardson
-  "63.204.168.", # Richardson
+  "63.204.168.",  # Richardson
   "65.69.103.",  # Richardson
   "65.70.203.",  # Richardson
   "66.138.5.",  # Richardson
   "67.39.101.",  # Richardson
-  "63.199.94.", # Richardson
-  "63.203.212.", # Richardson
-  "63.203.213.", # Richardson
-  "67.38.82.", # Richardson
-  "66.137.185.", # Richardson
-  "68.72.157.", # Richardson
-  "68.72.158.", # Richardson
-  "65.68.3.", # Richardson
-  "64.218.64.", # Richardson
-  "65.68.4.", # Richardson
-  "65.64.221.", # Richardson
-  "65.64.222.", # Richardson
-  "65.64.223.", # Richardson
-  "47.186.233.", # Richardson
-  "66.136.184.", # Richardson
-  "66.136.185.", # Richardson
-  "66.136.186.", # Richardson
-  "66.136.187.", # Richardson
-  "64.252.212.", # Richardson
-  "64.252.213.", # Richardson
-  "64.252.214.", # Richardson
-  "64.252.215.", # Richardson
-  "64.252.216.", # Richardson
-  "64.252.217.", # Richardson
-  "64.252.218.", # Richardson
-  "64.252.219.", # Richardson
-  "64.252.220.", # Richardson
-  "64.252.221.", # Richardson
-  "64.252.222.", # Richardson
-  "64.252.223.", # Richardson
-  "64.252.224.", # Richardson
-  "64.252.225.", # Richardson
-  "64.252.226.", # Richardson
-  "64.252.227.", # Richardson
-  "64.252.228.", # Richardson
-  "64.252.229.", # Richardson
-  "64.252.230.", # Richardson
-  "64.252.231.", # Richardson
-  "64.252.232.", # Richardson
-  "64.252.233.", # Richardson
-  "64.252.234.", # Richardson
-  "64.252.235.", # Richardson
-  "64.252.236.", # Richardson
-  "64.252.237.", # Richardson
-  "64.252.238.", # Richardson
-  "66.142.202.", # Richardson
+  "63.199.94.",  # Richardson
+  "63.203.212.",  # Richardson
+  "63.203.213.",  # Richardson
+  "67.38.82.",  # Richardson
+  "66.137.185.",  # Richardson
+  "68.72.157.",  # Richardson
+  "68.72.158.",  # Richardson
+  "65.68.3.",  # Richardson
+  "64.218.64.",  # Richardson
+  "65.68.4.",  # Richardson
+  "65.64.221.",  # Richardson
+  "65.64.222.",  # Richardson
+  "65.64.223.",  # Richardson
+  "47.186.233.",  # Richardson
+  "66.136.184.",  # Richardson
+  "66.136.185.",  # Richardson
+  "66.136.186.",  # Richardson
+  "66.136.187.",  # Richardson
+  "64.252.212.",  # Richardson
+  "64.252.213.",  # Richardson
+  "64.252.214.",  # Richardson
+  "64.252.215.",  # Richardson
+  "64.252.216.",  # Richardson
+  "64.252.217.",  # Richardson
+  "64.252.218.",  # Richardson
+  "64.252.219.",  # Richardson
+  "64.252.220.",  # Richardson
+  "64.252.221.",  # Richardson
+  "64.252.222.",  # Richardson
+  "64.252.223.",  # Richardson
+  "64.252.224.",  # Richardson
+  "64.252.225.",  # Richardson
+  "64.252.226.",  # Richardson
+  "64.252.227.",  # Richardson
+  "64.252.228.",  # Richardson
+  "64.252.229.",  # Richardson
+  "64.252.230.",  # Richardson
+  "64.252.231.",  # Richardson
+  "64.252.232.",  # Richardson
+  "64.252.233.",  # Richardson
+  "64.252.234.",  # Richardson
+  "64.252.235.",  # Richardson
+  "64.252.236.",  # Richardson
+  "64.252.237.",  # Richardson
+  "64.252.238.",  # Richardson
+  "66.142.202.",  # Richardson
   "68.72.114.",  # Richardson
   "63.174.141.",  # Rocksprings
-  "66.235.81.", # Rosenberg
+  "66.235.81.",  # Rosenberg
   "8.9.196.",  # San Antonio
   "12.211.20.",  # San Antonio
   "15.105.182.",  # San Antonio
@@ -324,72 +324,72 @@ ips = [
   "15.214.237.",  # San Antonio
   "15.216.199.",  # San Antonio
   "15.224.247.",  # San Antonio
-  "15.252.43.", # San Antonio
-  "15.150.168.", # San Antonio
-  "15.150.169.", # San Antonio
-  "40.141.126.", # San Antonio
-  "15.138.0.", # San Antonio
-  "15.138.1.", # San Antonio
-  "15.154.136.", # San Antonio
-  "15.154.137.", # San Antonio
-  "15.131.196.", # San Antonio
-  "15.131.197.", # San Antonio
-  "15.131.198.", # San Antonio
-  "15.131.199.", # San Antonio
-  "15.131.200.", # San Antonio
-  "15.143.78.", # San Antonio
-  "15.160.200.", # San Antonio
-  "15.160.201.", # San Antonio
-  "15.160.202.", # San Antonio
+  "15.252.43.",  # San Antonio
+  "15.150.168.",  # San Antonio
+  "15.150.169.",  # San Antonio
+  "40.141.126.",  # San Antonio
+  "15.138.0.",  # San Antonio
+  "15.138.1.",  # San Antonio
+  "15.154.136.",  # San Antonio
+  "15.154.137.",  # San Antonio
+  "15.131.196.",  # San Antonio
+  "15.131.197.",  # San Antonio
+  "15.131.198.",  # San Antonio
+  "15.131.199.",  # San Antonio
+  "15.131.200.",  # San Antonio
+  "15.143.78.",  # San Antonio
+  "15.160.200.",  # San Antonio
+  "15.160.201.",  # San Antonio
+  "15.160.202.",  # San Antonio
   "15.176.129.",  # San Antonio
-  "15.193.69.", # San Antonio
-  "15.193.70.", # San Antonio
-  "15.211.169.", # San Antonio
-  "15.132.71.", # San Antonio
-  "15.132.72.", # San Antonio
-  "15.190.132.", # San Antonio
-  "15.156.247.", # San Antonio
-  "15.156.248.", # San Antonio
-  "15.219.34.", # San Antonio
-  "15.176.79.", # San Antonio
-  "15.176.80.", # San Antonio
-  "15.176.81.", # San Antonio
-  "15.133.222.", # San Antonio
-  "12.207.43.", # San Antonio
-  "15.235.202.", # San Antonio
-  "15.235.203.", # San Antonio
-  "15.243.228.", # San Antonio
-  "15.243.229.", # San Antonio
-  "15.162.246.", # San Antonio
-  "15.162.247.", # San Antonio
-  "15.162.248.", # San Antonio
-  "15.162.249.", # San Antonio
-  "12.7.34.", # San Antonio
-  "12.7.35.", # San Antonio
-  "15.128.234.", # San Antonio
-  "15.128.235.", # San Antonio
-  "15.134.233.", # San Antonio
-  "15.134.234.", # San Antonio
-  "15.117.166.", # San Antonio
-  "15.159.219.", # San Antonio
-  "15.160.97.", # San Antonio
-  "15.160.98.", # San Antonio
-  "15.160.99.", # San Antonio
-  "15.189.87.", # San Antonio
-  "15.189.88.", # San Antonio
-  "15.120.172.", # San Antonio
-  "15.181.151.", # San Antonio
-  "15.181.152.", # San Antonio
-  "15.237.79.", # San Antonio
-  "15.157.163.", # San Antonio
+  "15.193.69.",  # San Antonio
+  "15.193.70.",  # San Antonio
+  "15.211.169.",  # San Antonio
+  "15.132.71.",  # San Antonio
+  "15.132.72.",  # San Antonio
+  "15.190.132.",  # San Antonio
+  "15.156.247.",  # San Antonio
+  "15.156.248.",  # San Antonio
+  "15.219.34.",  # San Antonio
+  "15.176.79.",  # San Antonio
+  "15.176.80.",  # San Antonio
+  "15.176.81.",  # San Antonio
+  "15.133.222.",  # San Antonio
+  "12.207.43.",  # San Antonio
+  "15.235.202.",  # San Antonio
+  "15.235.203.",  # San Antonio
+  "15.243.228.",  # San Antonio
+  "15.243.229.",  # San Antonio
+  "15.162.246.",  # San Antonio
+  "15.162.247.",  # San Antonio
+  "15.162.248.",  # San Antonio
+  "15.162.249.",  # San Antonio
+  "12.7.34.",  # San Antonio
+  "12.7.35.",  # San Antonio
+  "15.128.234.",  # San Antonio
+  "15.128.235.",  # San Antonio
+  "15.134.233.",  # San Antonio
+  "15.134.234.",  # San Antonio
+  "15.117.166.",  # San Antonio
+  "15.159.219.",  # San Antonio
+  "15.160.97.",  # San Antonio
+  "15.160.98.",  # San Antonio
+  "15.160.99.",  # San Antonio
+  "15.189.87.",  # San Antonio
+  "15.189.88.",  # San Antonio
+  "15.120.172.",  # San Antonio
+  "15.181.151.",  # San Antonio
+  "15.181.152.",  # San Antonio
+  "15.237.79.",  # San Antonio
+  "15.157.163.",  # San Antonio
   "24.173.86.",  # San Antonio
   "50.84.228.",  # San Antonio
   "50.95.50.",  # San Antonio
   "67.155.93.",  # San Antonio
   "68.98.252.",  # San Antonio
-  "24.155.227.", # San Marcos
-  "45.21.35." # Schertz
-  "67.78.77.", # Seguin
+  "24.155.227.",  # San Marcos
+  "45.21.35."  # Schertz
+  "67.78.77.",  # Seguin
   "67.179.27.",  # Seguin
   "12.205.32.",  # Sugar Land
   "50.162.51.",  # Sugar Land

--- a/bot/data.py
+++ b/bot/data.py
@@ -402,6 +402,7 @@ ips = [
 
 # random element from each list
 
+
 def anonymous_form():
   while True:
     city, county = random.choice(list(cities.items()))
@@ -418,8 +419,10 @@ def anonymous_form():
     }
     yield form_data
 
+
 def sign_up_page():
   raise NotImplementedError()
+
 
 def get_tip_body():
   rv = ''
@@ -432,11 +435,9 @@ def get_tip_body():
     else:
       logger.info('Using default key.')
     prompt = random.choice(gpt2_prompts)
-    r = requests.post(
-      "https://api.deepai.org/api/text-generator", data={
-        'text': prompt,
-      }, headers={'api-key': key}
-    )
+    r = requests.post("https://api.deepai.org/api/text-generator", data={
+      'text': prompt,
+    }, headers={'api-key': key})
     rv = str(r.json()['output'].encode('utf-8'))
     # cut out the prompt, which comes from a limited set and can be filtered on
     rv = rv.replace(prompt, '').lstrip()

--- a/bot/forms.py
+++ b/bot/forms.py
@@ -33,7 +33,7 @@ def get_nonce():
   }
 
   nonce = None
-  redirection.end_redirect()
+  redirection.redirect_to_target()
   logger.debug('Initiating GET request to /wp-admin/admin-ajax.php for the nonce.')
   try:
     response = requests.post('https://prolifewhistleblower.com/wp-admin/admin-ajax.php', data=payload, headers=headers)
@@ -51,7 +51,7 @@ def get_nonce():
     logger.error('Unable to retrieve the required nonce.')
     logger.debug(error)
   finally:
-    redirection.redirect()
+    redirection.redirect_to_localhost()
     return nonce
 
 
@@ -101,7 +101,6 @@ def anonymous_form(token):
     data[key] = generated_data[key]
   encoded_data = MultipartEncoder(fields=data)
   headers['content-type'] = encoded_data.content_type
-  data = encoded_data.to_string()
 
   nonce = get_nonce()
   if nonce == None:
@@ -110,7 +109,8 @@ def anonymous_form(token):
     data['forminator_nonce'] = nonce
 
   success = False
-  redirection.end_redirect()
+  data = encoded_data.to_string()
+  redirection.redirect_to_target()
   logger.debug('Initiating POST request to /wp-admin/admin-ajax.php to submit the form data.')
   try:
     response = session.post('https://prolifewhistleblower.com/wp-admin/admin-ajax.php', headers=headers, data=data)
@@ -131,7 +131,7 @@ def anonymous_form(token):
     logger.error('Unable to submit the form data.')
     logger.debug(error)
   finally:
-    redirection.redirect()
+    redirection.redirect_to_localhost()
     return success
 
 

--- a/bot/forms.py
+++ b/bot/forms.py
@@ -106,6 +106,8 @@ def anonymous_form(token):
   nonce = get_nonce()
   if nonce == None:
     return
+  else:
+    data['forminator_nonce'] = nonce
 
   success = False
   redirection.end_redirect()

--- a/bot/prompt.py
+++ b/bot/prompt.py
@@ -2,221 +2,205 @@
 import random
 
 suspect_words = [
-    'suspect',
-    'have reason to suspect',
-    'believe',
-    'have reason to believe',
-    'think',
-    'have evidence',
-    'have strong evidence',
-    'am convinced',
-    'am certain',
+  'suspect',
+  'have reason to suspect',
+  'believe',
+  'have reason to believe',
+  'think',
+  'have evidence',
+  'have strong evidence',
+  'am convinced',
+  'am certain',
 ]
 my_family_words = [
-    (0.5, 'father'),
-    (0.5, 'mother'),
-    (1.0, 'brother'),
-    (1.0, 'sister'),
-    (0.5, 'older brother'),
-    (0.5, 'older sister'),
-    (0.5, 'younger brother'),
-    (0.5, 'younger sister'),
-    (1.0, 'cousin'),
-    (2.0, 'aunt'),
-    (0.5, 'uncle'),
-    (0.6, 'daughter'),
-    (0.6, 'son'),
-    (0.2, 'step-son'),
-    (0.1, 'step son'),
-    (0.2, 'step-daughter'),
-    (0.1, 'step daughter'),
-    (0.7, 'nephew'),
-    (0.7, 'niece'),
-    (0.5, 'grandmother'),
-    (0.2, 'grandma'),
-    (0.5, 'grandfather'),
-    (0.2, 'grandpa'),
-    (0.5, 'granddad'),
-    (1.0, 'grandson'),
-    (1.0, 'granddaughter'),
-    (1.0, 'son-in-law'),
-    (1.0, 'daughter-in-law'),
-    (1.0, 'mother-in-law'),
-    (1.0, 'father-in-law'),
-    (0.1, 'half-brother'),
-    (0.1, 'half-sister'),
+  (0.5, 'father'),
+  (0.5, 'mother'),
+  (1.0, 'brother'),
+  (1.0, 'sister'),
+  (0.5, 'older brother'),
+  (0.5, 'older sister'),
+  (0.5, 'younger brother'),
+  (0.5, 'younger sister'),
+  (1.0, 'cousin'),
+  (2.0, 'aunt'),
+  (0.5, 'uncle'),
+  (0.6, 'daughter'),
+  (0.6, 'son'),
+  (0.2, 'step-son'),
+  (0.1, 'step son'),
+  (0.2, 'step-daughter'),
+  (0.1, 'step daughter'),
+  (0.7, 'nephew'),
+  (0.7, 'niece'),
+  (0.5, 'grandmother'),
+  (0.2, 'grandma'),
+  (0.5, 'grandfather'),
+  (0.2, 'grandpa'),
+  (0.5, 'granddad'),
+  (1.0, 'grandson'),
+  (1.0, 'granddaughter'),
+  (1.0, 'son-in-law'),
+  (1.0, 'daughter-in-law'),
+  (1.0, 'mother-in-law'),
+  (1.0, 'father-in-law'),
+  (0.1, 'half-brother'),
+  (0.1, 'half-sister'),
 ]
 subjects = [
-    'science',
-    'math',
-    'history',
-    'social studies',
-    'chemistry',
-    'algebra',
-    'Spanish',
-    'calculus',
-    'art',
-    'music',
-    'P.E.',
-    'gym',
-    'English',
+  'science',
+  'math',
+  'history',
+  'social studies',
+  'chemistry',
+  'algebra',
+  'Spanish',
+  'calculus',
+  'art',
+  'music',
+  'P.E.',
+  'gym',
+  'English',
 ]
 my_teacher_words = [
-    (1.0, 'teacher'),
-    *[
-        (0.2, k + ' teacher') for k in subjects
-    ],
-    (0.5, 'tutor'),
-    *[
-        (0.1, k + ' tutor') for k in subjects
-    ],
-    (1.0, 'babysitter')
+  (1.0, 'teacher'), *[(0.2, k + ' teacher') for k in subjects], (0.5, 'tutor'), *[(0.1, k + ' tutor') for k in subjects],
+  (1.0, 'babysitter')
 ]
 my_nonfamily_words = [
-    (2.0, 'neighbor'),
-    (0.6, 'next-door neighbor'),
-    (1.5, 'boss'),
-    (0.7, 'landlord'),
-    (1.5, 'doctor'),
-    (0.7, 'employee'),
-    (0.5, 'roommate'),
-    (1.0, 'friend'),
-    (1.0, 'girlfriend'),
-    (1.0, 'boyfriend'),
-    (0.3, 'maid'),
-    (0.2, 'live-in maid'),
-    (0.1, 'live in maid'),
-    (2.0, 'ex'),
-    (0.3, 'therapist'),
-    (0.5, 'supervisor'),
-    (1.0, 'employer'),
-    (0.2, 'lawyer'),
-    (0.4, 'dentist'),
-    (0.2, 'plumber'),
-    (1.5, 'pastor'),
-    (0.5, 'deacon'),
-    (0.8, 'priest'),
-    (0.2, 'accountant'),
+  (2.0, 'neighbor'),
+  (0.6, 'next-door neighbor'),
+  (1.5, 'boss'),
+  (0.7, 'landlord'),
+  (1.5, 'doctor'),
+  (0.7, 'employee'),
+  (0.5, 'roommate'),
+  (1.0, 'friend'),
+  (1.0, 'girlfriend'),
+  (1.0, 'boyfriend'),
+  (0.3, 'maid'),
+  (0.2, 'live-in maid'),
+  (0.1, 'live in maid'),
+  (2.0, 'ex'),
+  (0.3, 'therapist'),
+  (0.5, 'supervisor'),
+  (1.0, 'employer'),
+  (0.2, 'lawyer'),
+  (0.4, 'dentist'),
+  (0.2, 'plumber'),
+  (1.5, 'pastor'),
+  (0.5, 'deacon'),
+  (0.8, 'priest'),
+  (0.2, 'accountant'),
 ]
-my_family_possessive_adj = [
-    (k[0], k[1] + "'s ") for k in my_nonfamily_words
-]
+my_family_possessive_adj = [(k[0], k[1] + "'s ") for k in my_nonfamily_words]
 my_family_possessive_adj.append((20.0, ''))
-my_nonfamily_possessive_adj = [
-    (k[0], k[1] + "'s ") for k in my_family_words
-]
+my_nonfamily_possessive_adj = [(k[0], k[1] + "'s ") for k in my_family_words]
 my_nonfamily_possessive_adj.append((20.0, ''))
 my_teacher_possessive_adj = [
-    (0.2, 'younger brother'),
-    (0.2, 'younger sister'),
-    (0.8, 'brother'),
-    (0.8, 'sister'),
-    (1.0, 'cousin'),
-    (2.0, 'daughter'),
-    (2.0, 'son'),
-    (0.4, 'step-son'),
-    (0.2, 'step son'),
-    (0.4, 'step-daughter'),
-    (0.2, 'step daughter'),
-    (0.7, 'nephew'),
-    (0.7, 'niece'),
+  (0.2, 'younger brother'),
+  (0.2, 'younger sister'),
+  (0.8, 'brother'),
+  (0.8, 'sister'),
+  (1.0, 'cousin'),
+  (2.0, 'daughter'),
+  (2.0, 'son'),
+  (0.4, 'step-son'),
+  (0.2, 'step son'),
+  (0.4, 'step-daughter'),
+  (0.2, 'step daughter'),
+  (0.7, 'nephew'),
+  (0.7, 'niece'),
 ]
-my_teacher_possessive_adj = [ (k[0], k[1] + "'s ") for k in my_teacher_possessive_adj ]
-violated_words = [
-    'violated', 'disregarded', 'disobeyed'
-]
+my_teacher_possessive_adj = [(k[0], k[1] + "'s ") for k in my_teacher_possessive_adj]
+violated_words = ['violated', 'disregarded', 'disobeyed']
 days_of_the_week = [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday',
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
 ]
-got_words = [
-    'got', 'had'
-]
+got_words = ['got', 'had']
 past_time_frames = [
-    'last week', 'last month', 'this week', 'this month', 'yesterday', 'a week ago', 'two weeks ago', 'two days ago', 'on the weekend', 'this weekend', 'last weekend'
+  'last week', 'last month', 'this week', 'this month', 'yesterday', 'a week ago', 'two weeks ago', 'two days ago', 'on the weekend',
+  'this weekend', 'last weekend'
 ]
-past_time_frames.extend([ 'last ' + k for k in days_of_the_week ])
-past_time_frames.extend([ 'on ' + k for k in days_of_the_week ])
-will_get_words = [
-    'is getting', 'will get', 'plans on having', 'is trying to get', 'is trying to have', 'will try to get'
-]
+past_time_frames.extend(['last ' + k for k in days_of_the_week])
+past_time_frames.extend(['on ' + k for k in days_of_the_week])
+will_get_words = ['is getting', 'will get', 'plans on having', 'is trying to get', 'is trying to have', 'will try to get']
 future_time_frames = [
-    'next week', 'this week', 'tomorrow', 'two days from now', 'a week from now', 'after she leaves work', 'after work', 'on the weekend', 'this weekend', 'next weekend'
+  'next week', 'this week', 'tomorrow', 'two days from now', 'a week from now', 'after she leaves work', 'after work', 'on the weekend',
+  'this weekend', 'next weekend'
 ]
-future_time_frames.extend([ 'next ' + k for k in days_of_the_week ])
-future_time_frames.extend([ 'on ' + k for k in days_of_the_week ])
+future_time_frames.extend(['next ' + k for k in days_of_the_week])
+future_time_frames.extend(['on ' + k for k in days_of_the_week])
 abortion_ban_words = [
-    'abortion ban', 'ban on abortion', 'new abortion law', 'law on abortion', 'recent abortion law', 'abortion restrictions', 'restrictions on abortion', 'law'
+  'abortion ban', 'ban on abortion', 'new abortion law', 'law on abortion', 'recent abortion law', 'abortion restrictions',
+  'restrictions on abortion', 'law'
 ]
-abortion_ban_words = [ *["Texas's " + k for k in abortion_ban_words], *["the " + k for k in abortion_ban_words] ]
+abortion_ban_words = [*["Texas's " + k for k in abortion_ban_words], *["the " + k for k in abortion_ban_words]]
 abortion_ban_words.extend(['Texas law', 'the new law'])
 
+
 def random_select_weighted_list(ls):
-    return random.choices([k[1] for k in ls], weights = [k[0] for k in ls], k = 1)[0]
+  return random.choices([k[1] for k in ls], weights=[k[0] for k in ls], k=1)[0]
+
 
 def gen_abortion_prompt_I(accused):
-    abortion_prompt = 'I '
-    abortion_prompt += random.choice(suspect_words)
-    abortion_prompt += random.choices([' that', ''], weights = [0.75, 0.25], k = 1)[0]
-    abortion_prompt += ' my '
-    abortion_prompt += accused
-    abortion_prompt += random.choice([' has ', ' '])
-    abortion_prompt += random.choice(violated_words)
-    abortion_prompt += ' '
-    abortion_prompt += random.choice(abortion_ban_words)
-    abortion_prompt += '.'
-    return abortion_prompt
+  abortion_prompt = 'I '
+  abortion_prompt += random.choice(suspect_words)
+  abortion_prompt += random.choices([' that', ''], weights=[0.75, 0.25], k=1)[0]
+  abortion_prompt += ' my '
+  abortion_prompt += accused
+  abortion_prompt += random.choice([' has ', ' '])
+  abortion_prompt += random.choice(violated_words)
+  abortion_prompt += ' '
+  abortion_prompt += random.choice(abortion_ban_words)
+  abortion_prompt += '.'
+  return abortion_prompt
+
 
 def gen_abortion_prompt_My(accused):
-    abortion_prompt = 'My '
-    abortion_prompt += accused
+  abortion_prompt = 'My '
+  abortion_prompt += accused
+  abortion_prompt += ' '
+  past = random.random() > 0.5
+  if past:
+    abortion_prompt += random.choice(got_words)
+  else:
+    abortion_prompt += random.choice(will_get_words)
+  abortion_prompt += ' an'
+  abortion_prompt += random.choices(['', ' illegal', ' unlawful'], weights=[0.625, 0.375 / 2.0, 0.375 / 2.0], k=1)[0]
+  abortion_prompt += ' abortion'
+  if random.random() > 0.5:
     abortion_prompt += ' '
-    past = random.random() > 0.5
     if past:
-        abortion_prompt += random.choice(got_words)
+      abortion_prompt += random.choice(past_time_frames)
     else:
-        abortion_prompt += random.choice(will_get_words)
-    abortion_prompt += ' an'
-    abortion_prompt += random.choices(['', ' illegal', ' unlawful'], weights = [ 0.625, 0.375 / 2.0, 0.375 / 2.0 ], k = 1)[0]
-    abortion_prompt += ' abortion'
-    if random.random() > 0.5:
-        abortion_prompt += ' '
-        if past:
-            abortion_prompt += random.choice(past_time_frames)
-        else:
-            abortion_prompt += random.choice(future_time_frames)
-    abortion_prompt += '.'
-    return abortion_prompt
+      abortion_prompt += random.choice(future_time_frames)
+  abortion_prompt += '.'
+  return abortion_prompt
+
 
 def gen_abortion_prompt():
-    accused_family_person = random_select_weighted_list(my_family_possessive_adj)
-    accused_family_person += random_select_weighted_list(my_family_words)
-    accused_nonfamily_person = random_select_weighted_list(my_nonfamily_possessive_adj)
-    accused_nonfamily_person += random_select_weighted_list(my_nonfamily_words)
-    accused_teacher = random_select_weighted_list(my_teacher_possessive_adj)
-    accused_teacher += random_select_weighted_list(my_teacher_words)
-    accused = random_select_weighted_list([
-        (1.0, accused_family_person),
-        (1.5, accused_nonfamily_person),
-        (0.5, accused_teacher)
-    ])
-    abortion_prompts = [
-        (5.2, gen_abortion_prompt_I(accused)),
-        (2.6, gen_abortion_prompt_My(accused))
-    ]
-    return random_select_weighted_list(abortion_prompts)
+  accused_family_person = random_select_weighted_list(my_family_possessive_adj)
+  accused_family_person += random_select_weighted_list(my_family_words)
+  accused_nonfamily_person = random_select_weighted_list(my_nonfamily_possessive_adj)
+  accused_nonfamily_person += random_select_weighted_list(my_nonfamily_words)
+  accused_teacher = random_select_weighted_list(my_teacher_possessive_adj)
+  accused_teacher += random_select_weighted_list(my_teacher_words)
+  accused = random_select_weighted_list([(1.0, accused_family_person), (1.5, accused_nonfamily_person), (0.5, accused_teacher)])
+  abortion_prompts = [(5.2, gen_abortion_prompt_I(accused)), (2.6, gen_abortion_prompt_My(accused))]
+  return random_select_weighted_list(abortion_prompts)
+
 
 if __name__ == "__main__":
-    total_number = 2000000
-    sample_abortion_prompts = { gen_abortion_prompt() for k in range(total_number) }
-    for k in sorted(list(sample_abortion_prompts)[:200], key = lambda o: random.random()):
-        print(k)
-    print(total_number - len(sample_abortion_prompts))
-    print(len(sample_abortion_prompts))
-    print(len([k for k in sample_abortion_prompts if 'I' in k]))
-    print(len(sample_abortion_prompts) - len([k for k in sample_abortion_prompts if 'I' in k]))
+  total_number = 2000000
+  sample_abortion_prompts = {gen_abortion_prompt() for k in range(total_number)}
+  for k in sorted(list(sample_abortion_prompts)[:200], key=lambda o: random.random()):
+    print(k)
+  print(total_number - len(sample_abortion_prompts))
+  print(len(sample_abortion_prompts))
+  print(len([k for k in sample_abortion_prompts if 'I' in k]))
+  print(len(sample_abortion_prompts) - len([k for k in sample_abortion_prompts if 'I' in k]))

--- a/bot/redirection.py
+++ b/bot/redirection.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 from .logger import logger
+from .arguments import args
 
 hosts_filename = ''
 if os.name == 'nt':
@@ -10,31 +11,44 @@ else:
 
 logger.debug('hosts filename is ' + hosts_filename)
 
-# Opens OS specific hosts file and appends localhost as website URL
-# Might be easy to pivot to new sites later if we add all prolifewhistleblower.com entries to a static file
-def redirect():
-  # Redirect prolifewhistleblower.com to 127.0.0.1
-  logger.debug('Redirecting prolifewhistleblower.com to 127.0.0.1')
+
+# Returns the contents of the OS specific hosts file without any redirects
+# regarding the domain specified in cmdline arguments
+def get_hosts_without_redirection():
+  # Get the hosts file without the redirect
+  logger.debug(f'Getting the hosts file without the redirect to {args.domain}')
   try:
-    with open(hosts_filename, 'a') as hosts:
-      hosts.write('\n127.0.0.1 prolifewhistleblower.com\n')
+    with open(hosts_filename, 'r') as hosts_file:
+      return ''.join([line for line in hosts_file.readlines() if not args.domain in line]).rstrip() + '\n'
+  except IOError:
+    logger.critical('Unable to read {}'.format(hosts_filename))
+    print('Please run again but with sudo, as Administrator, or a user with write access to the hosts file.')
+    exit(1)
+
+
+# Opens OS specific hosts file and redirects the domain specified in cmdline arguments to localhost
+def redirect_to_localhost():
+  logger.debug(f'Redirecting {args.domain} to 127.0.0.1')
+  try:
+    with open(hosts_filename, 'a') as hosts_file:
+      hosts_file.write(f'127.0.0.1 {args.domain}\n')
   except IOError:
     logger.critical('Unable to append to {}'.format(hosts_filename))
     print('Please run again but with sudo, as Administrator, or a user with write access to the hosts file.')
     exit(1)
 
 
-def end_redirect():
-  # Remove the redirect from the hosts file
-  logger.debug('Ending redirection of prolifewhistleblower.com')
+# Opens OS specific hosts file and redirects the domain specified in cmdline arguments to the IP address
+# specified in the cmdline arguments. If no IP address is specified, the redirect is removed.
+def redirect_to_target():
+  logger.debug('Redirecting {} to {}'.format(args.domain, args.target if args.target is not None else 'target'))
+  hosts_data = get_hosts_without_redirection()
   try:
-    with open(hosts_filename, 'r') as hosts:
-      lines = hosts.readlines()
-    with open(hosts_filename, 'w') as hosts:
-      for line in lines:
-        if not 'prolifewhistleblower.com' in line:
-          hosts.write(line)
+    with open(hosts_filename, 'w') as hosts_file:
+      hosts_file.write(hosts_data)
+      if args.target is not None:
+        hosts_file.write(f'{args.target} {args.domain}\n')
   except IOError:
-    logger.critical('Unable to remove the redirect we added to {}'.format(hosts_filename))
+    logger.critical('Unable to redirect back to the target {}'.format(hosts_filename))
     print('Please remove it yourself or run me with sudo, as Administrator, or a user with write access to the hosts file.')
     exit(1)

--- a/bot/server.py
+++ b/bot/server.py
@@ -81,14 +81,13 @@ class ReCaptchaRequestHandler(BaseHTTPRequestHandler):
 
 
 def serve():
-  # Append URL to hosts file
-  redirection.redirect()
+  redirection.redirect_to_localhost()
 
   #Creating Extended Base HTTP server
   server_address = ('', 8000)
   httpd = HTTPServer(server_address, ReCaptchaRequestHandler)
   print('Starting the web server at http://prolifewhistleblower.com:8000/')
-  
+
   #Serving until Ctrl+C, then gracefully exiting
   try:
     httpd.serve_forever()
@@ -97,7 +96,7 @@ def serve():
     print('Ctrl+C received, shutting down the web server.')
   finally:
     httpd.socket.close()
-    redirection.end_redirect()
+    redirection.redirect_to_target()
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ idna==3.2
 requests==2.26.0
 requests-toolbelt==0.9.1
 urllib3==1.26.6
+yapf==0.31.0


### PR DESCRIPTION
New command-line arguments

```text
  -t TARGET, --target TARGET
                        Specify the target's IP address. Useful if the domain is not working correctly on      
                        it's own.
  -d DOMAIN, --domain DOMAIN
                        Specify the target's fully qualified domain (FQDN). Useful if the target switches      
                        domains. Defaults to prolifewhistleblower.com
```

Currently working on fixing an issue where the target's server says responds with the following when submitting the form:

```json
{"success":false,"data":"Invalid nonce. Please refresh your browser."}
```

I added an option to manually specify the nonce. I think it is the server that is broken right now and not the script since I can make the request successfully in Insomnia with no data sometimes.