### PR TITLE
Documentation: Adding Virtual Environment Instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     + [Generating text dynamically](#generating-text-dynamically)
   * [Usage](#usage)
   * [Using a Virtual Environment](#using-a-virtual-environment)
-    + [Setup for Linux and MacOS](#setup-for-linux-and-macos)
+    + [Setup for Linux and macOS](#setup-for-linux-and-macos)
     + [Setup for Windows](#setup-for-windows)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
@@ -68,7 +68,7 @@ https://git-scm.com/downloads
 
 ### Clone the repo
 use powershell or cmd.exe on Windows
-terminal if on MacOS
+terminal if on macOS
 if on Linux, your terminal of choice
 
 ```bash
@@ -274,7 +274,7 @@ A virtual environment creates a local installation of Python, where the installe
 
 ### Setup
 
-#### Setup for Linux and MacOS
+#### Setup for Linux and macOS
 
 To create a virtual environment, make sure you are in the `AbBOT-python` directory, then execute:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
   * [How it looks in action](#how-it-looks-in-action)
     + [Generating text dynamically](#generating-text-dynamically)
   * [Usage](#usage)
+  * [Using a Virtual Environment](#using-a-virtual-environment)
+    + [Setup for Linux and MacOS](#setup-for-linux-and-macos)
+    + [Setup for Windows](#setup-for-windows)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -71,7 +74,7 @@ if on Linux, your terminal of choice
 ```bash
 git clone https://github.com/ramblingjordan/AbBOT-python.git
 
-cd AbBot
+cd AbBOT-python
 ```
 
 ### Windows
@@ -80,7 +83,7 @@ If you don't already have `python3.exe` and `pip3.exe` installed on Windows, you
 
 https://www.microsoft.com/en-us/p/python-39/9p7qfqmjrfp7
 
-Now we can install the required Python 3 packages for this project.
+Now we can install the required Python 3 packages for this project. Before you install the packages, consider [setting up a virtual environment for development](#using-a-virtual-environment).
 
 ```powershell
 pip3.exe install -r .\requirements.txt
@@ -119,23 +122,7 @@ If you already have `python3` installed, make sure your have the latest version 
 python3 -m pip install --user --upgrade pip
 ```
 
-Before you install the required Python 3 packages, you can *optionally* create a virtual environment that will separate the installed packages from your main python installation. A virtual environment creates a local installation of Python, where the installed packages will be isolated from the packages installed by the main Python installation, which allows you to better keep track of what packages are used. This is recommended, especially if you are planning to help develop the bot. The package `venv` is shipped with Python 3.3 or later.
-
-To create a virtual environment, make sure you are in the `AbBOT` directory, then execute:
-
-```bash
-python3 -m venv .env
-```
-
-This creates a directory `AbBOT/.env`, which contains the virtual Python installation, and will not to uploaded to GitHub during commits. Then source the activate file to use the virtual environment.
-
-```bash
-source ./.env/bin/activate
-```
-
-To check that you are in virtual environment, the command `which python3` should return a path that ends in `.../AbBOT/.env/bin/python3`. Now you could install the required packages *inside* the virtual environment. To leave the virtual environment and return to your main Python installation, simply use `deactivate`.
-
-Now we can install the required Python 3 packages for this project, regardless of whether or not you are using `venv`.
+Now we can install the required Python 3 packages for this project. Before you install the packages, consider [setting up a virtual environment for development](#using-a-virtual-environment).
 
 ```bash
 python3 -m pip install -r ./requirements.txt
@@ -151,7 +138,7 @@ sudo python3 ./main.py
 sudo ./main.py
 ```
 
-If you installed `python3`/`pip3` t to your account and not to the system, you will want to keep your `PATH` when using `sudo`.
+If you installed `python3`/`pip3` to your account and not to the system, you will want to keep your `PATH` when using `sudo`.
 
 ```bash
 sudo env "PATH=$PATH" python3 ./main.py
@@ -178,9 +165,13 @@ If you don't have `python3` or `pip3` installed you can either download the inst
 brew install python3
 ```
 
-You could also set up a virtual environment for OS X via `venv` using the same instructions as above in the Linux section.
+If you already have `python3` installed, make sure your have the latest version of `pip3` installed. You can update your `pip3` installation as follows.
 
-Now we can install the required Python 3 packages for this project.
+```bash
+python3 -m pip install --user --upgrade pip
+```
+
+Now we can install the required Python 3 packages for this project. Before you install the packages, consider [setting up a virtual environment for development](#using-a-virtual-environment).
 
 ```bash
 pip3 install -r ./requirements.txt
@@ -276,3 +267,41 @@ optional arguments:
   -g, --generate
                         Generate GPT2 text from DeepAI API with key set by environment variable or default.
 ```
+
+## Using a Virtual Environment
+
+A virtual environment creates a local installation of Python, where the installed packages will be isolated from the packages installed by the main Python installation, which allows you to better keep track of what packages are used. For example, if your program requires a new module during development, you could update the requirements file via `pip freeze > requirements.txt` on Linux and macOS. This is recommended, especially if you are planning to help develop the bot. The package `venv` is shipped with Python 3.3 or later.
+
+### Setup
+
+#### Setup for Linux and MacOS
+
+To create a virtual environment, make sure you are in the `AbBOT-python` directory, then execute:
+
+```bash
+python3 -m venv .env
+```
+
+This creates a directory `AbBOT-python/.env`, which contains the virtual Python installation, and will not to uploaded to GitHub during commits. Then source the activate file to use the virtual environment.
+
+```bash
+source ./.env/bin/activate
+```
+
+To check that you are in virtual environment, the command `which python3` should return a path that ends in `.../AbBOT-python/.env/bin/python3`. Now you could install the required packages *inside* the virtual environment. To leave the virtual environment and return to your main Python installation, simply use `deactivate`.
+
+#### Setup for Windows
+
+To create a virtual environment, make sure you are in the `AbBOT-python` directory, then execute:
+
+```
+python3.exe -m venv .env
+```
+
+This creates a directory `AbBOT-python\.env`, which contains the virtual Python installation, and will not to uploaded to GitHub during commits. Then source the activate file to use the virtual environment (again, making sure that you are in the `AbBOT-python` directory).
+
+```
+.\env\Scripts\activate
+```
+
+To check that you are in virtual environment, the command `which python3` should return a path that ends in `...\AbBOT-python\.env\Scripts\python.exe`. Now you could install the required packages *inside* the virtual environment. To leave the virtual environment and return to your main Python installation, simply use `deactivate`.

--- a/README.md
+++ b/README.md
@@ -113,10 +113,32 @@ If you don't have `python3` or `pip3` installed, you can install the `python3` p
 sudo apt install python3
 ```
 
-Now we can install the required Python 3 packages for this project.
+If you already have `python3` installed, make sure your have the latest version of `pip3` installed. You can update your `pip3` installation as follows.
 
 ```bash
-pip3 install -r ./requirements.txt
+python3 -m pip install --user --upgrade pip
+```
+
+Before you install the required Python 3 packages, you can *optionally* create a virtual environment that will separate the installed packages from your main python installation. A virtual environment creates a local installation of Python, where the installed packages will be isolated from the packages installed by the main Python installation, which allows you to better keep track of what packages are used. This is recommended, especially if you are planning to help develop the bot. The package `venv` is shipped with Python 3.3 or later.
+
+To create a virtual environment, make sure you are in the `AbBOT` directory, then execute:
+
+```bash
+python3 -m venv .env
+```
+
+This creates a directory `AbBOT/.env`, which contains the virtual Python installation, and will not to uploaded to GitHub during commits. Then source the activate file to use the virtual environment.
+
+```bash
+source ./.env/bin/activate
+```
+
+To check that you are in virtual environment, the command `which python3` should return a path that ends in `.../AbBOT/.env/bin/python3`. Now you could install the required packages *inside* the virtual environment. To leave the virtual environment and return to your main Python installation, simply use `deactivate`.
+
+Now we can install the required Python 3 packages for this project, regardless of whether or not you are using `venv`.
+
+```bash
+python3 -m pip install -r ./requirements.txt
 ```
 
 #### Running the program
@@ -155,6 +177,8 @@ If you don't have `python3` or `pip3` installed you can either download the inst
 ```bash
 brew install python3
 ```
+
+You could also set up a virtual environment for OS X via `venv` using the same instructions as above in the Linux section.
 
 Now we can install the required Python 3 packages for this project.
 


### PR DESCRIPTION
Virtual Environment Instructions added for Linux and OS X only.

New contributors should use a Virtual Environment to make sure their python installation has the same packages as the requirements, and should they use a new package, they could update `requirements.txt` via `pip freeze`. The `README.md` installation documentation was updated for Linux and OS X with instructions to set up a Virtual Environment via `venv` for Python 3.